### PR TITLE
Added company-solidity for Emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [linter-solidity](https://atom.io/packages/linter-solidity) - Linter.
 
 #### Emacs
+- [company-solidity](https://github.com/ssmolkin1/company-solidity) - Autocomplete with company-mode.
 - [emacs-solidity](https://github.com/ethereum/emacs-solidity) - Solidity mode for Emacs.
 
 #### IntelliJ


### PR DESCRIPTION
Added company-solidity, an auto-completion plugin for Emacs.

Checklist
------------

* [x ] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [ x] Drop all the `A` / `An` prefixes in the descriptions.
* [ x] Avoid using the word `Solidity` in the description.
