### PR TITLE
Added dapp-scratch to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [Truffle](https://github.com/ConsenSys/truffle) - Development environment, testing framework and asset pipeline for Ethereum.
 - [Zeppelin](https://github.com/OpenZeppelin/zeppelin-solidity) - Framework to build secure smart contracts.
 - [DappTools](https://dapp.tools/) - Command-line-friendly tools for blockchain development.
+- [dapp-scratch](https://github.com/okwme/dapp-scratch) - CLI for generating js module for Dapp from contract code.
 
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 
 ## Libraries
 - [dapp-bin](https://github.com/ethereum/dapp-bin) - Ethereum repo providing implementations for many common data structures and utilities in Solidity, Serpent and LLL.
+- [dapp-scratch](https://github.com/okwme/dapp-scratch) - CLI for generating js module for Dapp from contract code.
 - [dappsys](https://github.com/nexusdev/dappsys) - Contract system framework for flexible multi-contract dapps.
+- [DappTools](https://dapp.tools/) - Command-line-friendly tools for blockchain development.
 - [instant-dapp-ide](https://github.com/dominicwilliams/instant-dapp-ide) - Complete Dapp and Solidity development environment as a docker image you can run from command line.
 - [Modular Libraries](https://github.com/modular-network/ethereum-libraries) - Deployed utility libraries to use in your smart contracts.
 - [Smart Contracts Skeleton](https://github.com/Shimmi/smart-contracts-skeleton) - Preconfigured skeleton repository for building or starting with development of Smart contracts.
@@ -69,8 +71,6 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [sqlsol](https://github.com/monax/sqlsol) - Event-driven SQLite3 cache for syncing with smart contracts.
 - [Truffle](https://github.com/ConsenSys/truffle) - Development environment, testing framework and asset pipeline for Ethereum.
 - [Zeppelin](https://github.com/OpenZeppelin/zeppelin-solidity) - Framework to build secure smart contracts.
-- [DappTools](https://dapp.tools/) - Command-line-friendly tools for blockchain development.
-- [dapp-scratch](https://github.com/okwme/dapp-scratch) - CLI for generating js module for Dapp from contract code.
 
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 
 ## Libraries
 - [dapp-bin](https://github.com/ethereum/dapp-bin) - Ethereum repo providing implementations for many common data structures and utilities in Solidity, Serpent and LLL.
-- [dapp-scratch](https://github.com/okwme/dapp-scratch) - CLI for generating js module for Dapp from contract code.
+- [dapp-scratch](https://github.com/okwme/dapp-scratch) - CLI for generating javascript modules from Contracts for Decentralized Apps.
 - [dappsys](https://github.com/nexusdev/dappsys) - Contract system framework for flexible multi-contract dapps.
 - [DappTools](https://dapp.tools/) - Command-line-friendly tools for blockchain development.
 - [instant-dapp-ide](https://github.com/dominicwilliams/instant-dapp-ide) - Complete Dapp and Solidity development environment as a docker image you can run from command line.


### PR DESCRIPTION
added a library for generating javascript modules from contract code.
[link](https://github.com/okwme/dapp-scratch)

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
