### PR TITLE
Add link to Solidity cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [CryptoZombies](https://cryptozombies.io) - Interactive code school that teaches you to write smart contracts through building your own crypto-collectables game.
 - [Hackr.io Tutorials](https://hackr.io/tutorials/learn-solidity) - Community curated tutorials and courses.
 - [LearnXInY](https://learnxinyminutes.com/docs/solidity/) - Learn Solidity in 15 mins (for experienced devs).
+- [Syntax cheat sheet](https://topmonks.github.io/solidity_quick_ref/) - Quick syntax overview.
 
 #### Security
 - [Capture the Ether](https://capturetheether.com/) - Game in which you hack Ethereum smart contracts to learn about security.


### PR DESCRIPTION
Hi, i added link to Solidity syntax cheat sheet i recently created when learning Solidity. It might help someone to get overview of what's possible or help new developers at the start of their learning

Here is link to the cheat sheet: https://topmonks.github.io/solidity_quick_ref/
And here is the repo: https://github.com/topmonks/solidity_quick_ref

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
