### PR TITLE
Added truffle-assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [Solidity Standard Library](https://github.com/alianse777/solidity-standard-library) - Standard library (Array, random, math, string).
 - [sqlsol](https://github.com/monax/sqlsol) - Event-driven SQLite3 cache for syncing with smart contracts.
 - [Truffle](https://github.com/ConsenSys/truffle) - Development environment, testing framework and asset pipeline for Ethereum.
+- [truffle-assertions](https://github.com/rkalis/truffle-assertions) - Adds additional assertions and utilities used in testing smart contracts with truffle.
 - [OpenZeppelin](https://openzeppelin.org/) - Framework to build secure smart contracts.
 
 


### PR DESCRIPTION
I added my `truffle-assertions` library, which is used mainly to assert that specific events with a specified event type have been emitted. The library also takes a filter function on the event arguments, allowing the developer to make the assertions as coarse or as fine-grained as needed.

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
