### PR TITLE
README.md: change Visual Studio -> Visual Studio Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [vim-solidity](https://github.com/tomlion/vim-solidity) - Vim syntax file.
 - [solidity.vim](https://github.com/dmdque/solidity.vim) - Vim compiler plugin.
 
-#### Visual Studio
+#### Visual Studio Code
 - [vscode-solidity](https://github.com/juanfranblanco/vscode-solidity) - Visual Studio Code language support extension.
 
 


### PR DESCRIPTION
They are completely two IDE/text editors and the only item [vscode-solidity](https://github.com/juanfranblanco/vscode-solidity) is for Visual Studio Code only.

Checklist
------------

* [X] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [X] Drop all the `A` / `An` prefixes in the descriptions.
* [X] Avoid using the word `Solidity` in the description.
