### PR TITLE
added cryptofex ide

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 
 ## Tools
 #### General
+- [Cryptofex](https://cryptofex.io/download/) - Standalone IDE and compiler.
 - [REPL](https://github.com/raineorshine/solidity-repl) - REPL CLI.
 - [solgraph](https://github.com/raineorshine/solgraph) - Visualize control flows for smart contract security analysis.
 - [Remix](https://remix.ethereum.org/) - Online realtime compiler and runtime.


### PR DESCRIPTION
Added Cryptofex, a standalone IDE for solidity and vyper smart contracts. It is a commercial product, but is free for non-commercial/open source work.

**DISCLOSURE:** I work on this for my job.

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
