### PR TITLE
fix Visual Studio Code anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
     - [Emacs](#emacs)
     - [Sublime](#sublime)
     - [Vim](#vim)
-    - [Visual Studio](#visual-studio)
+    - [Visual Studio Code](#visual-studio-code)
 - [License](#license)
 
 


### PR DESCRIPTION
fixes the broken cross-reference (named anchor) for Visual Studio Code

Checklist
------------

* [X] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [X] Drop all the `A` / `An` prefixes in the descriptions.
* [X] Avoid using the word `Solidity` in the description.
