### PR TITLE
add etheratom

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [autocomplete-solidity](https://atom.io/packages/autocomplete-solidity) - Parses Solidity files to give you contextual autocomplete suggestions.
 - [language-ethereum](https://atom.io/packages/language-ethereum) - Adds syntax highlighting and snippets to Solidity and Serpent files in Atom.
 - [linter-solidity](https://atom.io/packages/linter-solidity) - Linter.
+- [Etheratom](https://atom.io/packages/etheratom) - Compile and deploy solidity code from atom editor.
 
 #### Eclipse
 - [uml2solidity](https://github.com/UrsZeidler/uml2solidity) - Model smart contracts with UML.


### PR DESCRIPTION
atom plugin

[Please describe your pull request here]

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
