### PR TITLE
Added Tenderly to the list of general tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [solgraph](https://github.com/raineorshine/solgraph) - Visualize control flows for smart contract security analysis.
 - [sol-merger](https://github.com/RyuuGan/sol-merger) - Merges all imports into single file for contracts.
 - [solidity-docgen](https://github.com/OpenZeppelin/solidity-docgen) - Documentation generator for Solidity projects.
+- [Tenderly CLI](https://github.com/Tenderly/tenderly-cli) - Speed up your development with human readable stack traces.
 
 #### Audit
 - [Echidna](https://github.com/trailofbits/echidna) - Define properties for your smart contract then use fuzzing to catch security bugs.


### PR DESCRIPTION
As the title suggests added the Tenderly CLI to the list of general tools.

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
