### PR TITLE
Add truffle-plugin-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [sol-tester](https://github.com/androlo/sol-tester) - Utilities for building, linking and testing contracts using go-ethereum and the simulated chain.
 - [sol-verifier](https://github.com/Aniket-Engg/sol-verifier) - Verify solidity smart contracts on Etherscan.
 - [solidity-coverage](https://github.com/sc-forks/solidity-coverage) - Code coverage tool.
+- [truffle-plugin-verify](https://github.com/rkalis/truffle-plugin-verify) - Truffle plugin to verify smart contracts on Etherscan from the Truffle command line.
 
 #### Webpack
 - [solidity-loader](https://github.com/jeffscottward/solidity-loader) - Webpack loader.


### PR DESCRIPTION
Add truffle-plugin-verify to the list, which is a Truffle plugin allowing you to verify smart contracts on Etherscan with seamless Truffle integration.

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [x] Avoid using the word `Solidity` in the description.
