### PR TITLE
Added Solidity & Vyper cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Please check the [contribution guidelines](CONTRIBUTING.md) for info on formatti
 - [Monax Smart Contract Tutorial](https://github.com/monax/legacy-docs/tree/master/solidity) - Tutorial series which begins with a very simple smart contract and teaches how to gradually increase the complexity of your contracts with relevant design patterns.
 - [Solidity Workshop](https://github.com/androlo/solidity-workshop) - Comprehensive series of tutorials covering contract-oriented programming and advanced language concepts.
 - [Syntax cheat sheet](https://topmonks.github.io/solidity_quick_ref/) - Quick syntax overview.
+- [Solidity and Vyper cheat sheet](https://reference.auditless.com/cheatsheet) - Review syntax of both languages side-by-side
 
 <!-- 
 SSL cert is currently failing for `blog.colony.io`; will be removed permanently if it isn't fixed in the coming weeks.


### PR DESCRIPTION
[Please describe your pull request here]

Checklist
------------

* [x] Each link description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the Solidity compiler.`
* [x] Drop all the `A` / `An` prefixes in the descriptions.
* [ ] Avoid using the word `Solidity` in the description - using the word because the cheat sheet also includes Vyper :).
