### PR TITLE
Added Buildspace to Tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,36 +26,36 @@
 ### Contents
 
 - [Resources](#resources)
-    - [Official](#official)
-    - [Tutorials](#tutorials)
-    - [Articles](#articles)
-    - [Security](#security)
-    - [Examples](#examples)
-      - [Educational](#educational)
-      - [Deployed on Ethereum Mainnet](#deployed-on-ethereum-mainnet)
-    - [Templates](#templates)
-    - [Books](#books)
-    - [Practice](#practice)
-    - [Jobs](#jobs)
+  - [Official](#official)
+  - [Tutorials](#tutorials)
+  - [Articles](#articles)
+  - [Security](#security)
+  - [Examples](#examples)
+    - [Educational](#educational)
+    - [Deployed on Ethereum Mainnet](#deployed-on-ethereum-mainnet)
+  - [Templates](#templates)
+  - [Books](#books)
+  - [Practice](#practice)
+  - [Jobs](#jobs)
 - [Libraries](#libraries)
 - [Tools](#tools)
-    - [General](#general)
-    - [Utility](#utility)
-    - [Audit](#audit)
-    - [DevOps](#devops)
+  - [General](#general)
+  - [Utility](#utility)
+  - [Audit](#audit)
+  - [DevOps](#devops)
 - [Languages](#languages)
-    - [JavaScript](#javascript)
-    - [TypeScript](#typescript)
-    - [Rust](#rust)
-    - [OCaml](#ocaml)
+  - [JavaScript](#javascript)
+  - [TypeScript](#typescript)
+  - [Rust](#rust)
+  - [OCaml](#ocaml)
 - [Editor Plugins](#editor-plugins)
-    - [Atom](#atom)
-    - [Eclipse](#eclipse)
-    - [Emacs](#emacs)
-    - [IntelliJ](#intellij)
-    - [Sublime](#sublime)
-    - [Vim](#vim)
-    - [Visual Studio Code](#visual-studio-code)
+  - [Atom](#atom)
+  - [Eclipse](#eclipse)
+  - [Emacs](#emacs)
+  - [IntelliJ](#intellij)
+  - [Sublime](#sublime)
+  - [Vim](#vim)
+  - [Visual Studio Code](#visual-studio-code)
 - [License](#license)
 
 ## Resources
@@ -72,6 +72,7 @@
 
 #### Tutorials
 
+- [\_buildspace](https://buildspace.so/) - An hands-on Web3 course especially for beginners. It is completely free and you get a NFT on completion.
 - [androlo/solidity-workshop](https://github.com/androlo/solidity-workshop) - Comprehensive series of tutorials covering contract-oriented programming and advanced language concepts.
 - [CryptoZombies](https://cryptozombies.io) - Interactive code school that teaches you to write smart contracts through building your own crypto-collectibles game.
 - [cryptodevhub.io](https://cryptodevhub.io/) - Community-driven effort to unite like-minded people interested in Blockchain- and Crypto Technologies.
@@ -144,7 +145,7 @@
 - [paulrberg/solidity-template](https://github.com/paulrberg/solidity-template) - Github template for writing contracts (uses: Hardhat, TypeChain, Ethers, Waffle, Solhint, Solcover, Prettier Plugin Solidity).
 - [tomhirst/solidity-nextjs-starter](https://github.com/tomhirst/solidity-nextjs-starter) - A full-stack dApp starter built with Next.js (React).
 - [ZumZoom/solidity-template](https://github.com/ZumZoom/solidity-template) - Hardhat template with preconfigured Github Actions and Coveralls support.
-- [rhlsthrm/typescript-solidity-dev-starter-kit](https://github.com/rhlsthrm/typescript-solidity-dev-starter-kit) - Starter kit for developing, testing, and deploying smart contracts with a full Typescript environment. 
+- [rhlsthrm/typescript-solidity-dev-starter-kit](https://github.com/rhlsthrm/typescript-solidity-dev-starter-kit) - Starter kit for developing, testing, and deploying smart contracts with a full Typescript environment.
 
 #### Books
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 
 #### Tutorials
 
-- [\_buildspace](https://buildspace.so/) - An hands-on Web3 course especially for beginners. It is completely free and you get a NFT on completion.
+- [\_buildspace](https://buildspace.so/) - A hands-on Web3 course especially for beginners. It is completely free and you get a NFT on completion.
 - [androlo/solidity-workshop](https://github.com/androlo/solidity-workshop) - Comprehensive series of tutorials covering contract-oriented programming and advanced language concepts.
 - [CryptoZombies](https://cryptozombies.io) - Interactive code school that teaches you to write smart contracts through building your own crypto-collectibles game.
 - [cryptodevhub.io](https://cryptodevhub.io/) - Community-driven effort to unite like-minded people interested in Blockchain- and Crypto Technologies.


### PR DESCRIPTION
I recently completed the hands-on tutorial course with Buildspace and was very happy with the quality of the content. It's a completely free course and you even get an NFT after completion as a souvenir. I saw it was not in the list of tutorials, and I feel it's the best way to start with Web3, so I made this pull request.

p.s- this is also my first ever pull request :)

## Checklist

- [ x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ x] Drop all `A` / `An` prefixes at the start of the description.
- [ x] Avoid using the word `Solidity` in the description.
