### PR TITLE
Add "Teach Yourself Web3" to the tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 - [manojpramesh/solidity-cheatsheet](https://github.com/manojpramesh/solidity-cheatsheet) - Cheat sheet and best practices.
 - [Questbook](https://www.questbook.app/) - Questbook is building a University DAO where learning is always free. Starting with crypto-dev courses by leading devs.
 - [Solidity and Vyper cheat sheet](https://reference.auditless.com/cheatsheet) - Review syntax of both languages side-by-side.
+- [Teach Yourself Web3](https://www.teachyourselfweb3.com/) - Join a community of Web3 engineers & educators that can help you supercharge your way into Web3 development.
 - [topmonks/solidity_quick_ref](https://topmonks.github.io/solidity_quick_ref/) - Syntax overview.
 - [willitscale/learning-solidity](https://github.com/willitscale/learning-solidity) - Complete guide on getting started, creating your own crypto, ICOs and deployment.
 - [useweb3.xyz/tutorials](https://www.useweb3.xyz/tutorials) - A curated list of free, community tutorials that are based around specific projects, tasks or challenges.


### PR DESCRIPTION
This PR includes the "Teach Yourself Web3" resource in the Tutorials section. It's a free & structured learning experience designed to help experienced developers acquire foundational knowledge to start their path to becoming Web3 engineers.

## Checklist

- [ x ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ x ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ x ] Drop all `A` / `An` prefixes at the start of the description.
- [ x ] Avoid using the word `Solidity` in the description.
