### PR TITLE
docs: add alephao/solidity-benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [raineorshine/solidity-by-example](https://github.com/raineorshine/solidity-by-example) - A collection of short yet fully-functional contracts that demonstrate language features.
 - [Solidity By Example](https://solidity-by-example.org/) - An introduction to the language with simple examples.
 - [useWeb3 - Learn web3 development](https://www.useweb3.xyz/) - A curated overview of the best and latest resources on Ethereum, Solidity and Web3 development.
+- [alephao/solidity-benchmarks](https://github.com/alephao/solidity-benchmarks) - Benchmarks of popular implementations of ERC standards.
 
 ##### Deployed on Ethereum Mainnet
 


### PR DESCRIPTION
Adding [alephao/solidity-benchmarks](https://github.com/alephao/solidity-benchmarks). Which contains benchmarks of popular implementations of ERC20, ERC721 and ERC115 and is being actively maintained. 

The educational category seem like the best fit for me, but not sure.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Solidity` in the description.
