### PR TITLE
Adding blocktorch to the list in section web3 DevOps tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 
 - [Embark](https://github.com/embark-framework/embark) - Framework that allows you to easily develop and deploy DApps.
 - [Moesif](https://www.moesif.com/docs/platform/ethereum-web3/) - Service that provides Ethereum smart contract analytics and anomaly detection for DApps and DAPIs.
+- [Blocktorch](https://app.blocktorch.xyz) - Observability platform for the decentralized stack to see logs, metrics and traces in any decentralized component across chains.
 
 ## Languages
 


### PR DESCRIPTION
Adding [blocktorch](https://blocktorch.xyz) to the list in section web3 DevOps tools

## Checklist

- [ DONE] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ DONE] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ DONE] Drop all `A` / `An` prefixes at the start of the description.
- [ DONE] Avoid using the word `Solidity` in the description.
