### PR TITLE
remove Teach Yourself Web3 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@
 - [manojpramesh/solidity-cheatsheet](https://github.com/manojpramesh/solidity-cheatsheet) - Cheat sheet and best practices.
 - [Questbook](https://www.questbook.app/) - Questbook is building a University DAO where learning is always free. Starting with crypto-dev courses by leading devs.
 - [Solidity and Vyper cheat sheet](https://reference.auditless.com/cheatsheet) - Review syntax of both languages side-by-side.
-- [Teach Yourself Web3](https://www.teachyourselfweb3.com/) - Join a community of Web3 engineers & educators that can help you supercharge your way into Web3 development.
 - [topmonks/solidity_quick_ref](https://topmonks.github.io/solidity_quick_ref/) - Syntax overview.
 - [nishuzumi/Web3-Enterprise-level-engineering](https://github.com/nishuzumi/Web3-Enterprise-level-engineering) - Web3 Enterprise Engineering Writing Specification Tutorial [Chinese Language - 中文版].
 - [willitscale/learning-solidity](https://github.com/willitscale/learning-solidity) - Complete guide on getting started, creating your own crypto, ICOs and deployment.


### PR DESCRIPTION
This community is no longer active (even though the site is up). It should be removed so that readers are not lead astray.

## Checklist

- [X] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [X] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [X] Drop all `A` / `An` prefixes at the start of the description.
- [X] Avoid using the word `Solidity` in the description.
