### PR TITLE
Rectify spearbitDao preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 - [Consensys Diligence](https://consensys.net/diligence/audits/) - Public security audits by the Consensys Diligence Team.
 - [MixBytes](https://github.com/mixbytes/audits_public) - Public security audits by the MixBytes Team.
 - [Hacken](https://hacken.io/audits/) - Public security audits by the Hacken Team.
-- [SpearbitDAO] (https://github.com/spearbit/portfolio) - Public security audits by the SpearbitDAO Team.
+- [SpearbitDAO](https://github.com/spearbit/portfolio) - Public security audits by the SpearbitDAO Team.
 
 #### Examples
 


### PR DESCRIPTION
This pull request rectifies the preview link of spearbitDao in Audits section.

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Solidity` in the description.
