### PR TITLE
Add Agent Treasury Policy Linter under Tools/Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 #### Audit
 
 - [a16z/metamorphic-contract-detector](https://github.com/a16z/metamorphic-contract-detector) - Check whether a given contract exhibits red flags that could indicate the potential for metamorphism instead of immutability.
+- [Agent Treasury Policy Linter](https://github.com/Amara-ops/agent-guardrails-policy-linter) - Lints agent treasury policies (caps, allowlists, timelock/quorum) and blocks risky configs in CI. Samples + cookbook. MIT.
 - [Echidna](https://github.com/crytic/echidna) - Define properties for your smart contract then use fuzzing to catch security bugs.
 - [Manticore](https://github.com/trailofbits/manticore) - Detects many common bug types, and can prove correctness properties with symbolic execution.
 - [Mythril](https://github.com/ConsenSys/mythril) - Security analysis tool for smart contracts.


### PR DESCRIPTION
Agents/programmable treasuries need policy-as-code. This linter validates an agent-treasury policy JSON against a schema and safety rules (caps, selector+chainId allowlists, timelock, quorum, pause, logging) in CI. Outputs machine-readable actionable JSON reports with errors/warnings/suggestions to help teams tighten policy before deployment. Repo: https://github.com/Amara-ops/agent-guardrails-policy-linter