### PR TITLE
feat: add Verity to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [Tenderly](https://tenderly.co) - Easily monitor your smart contracts with error tracking, alerting, performance metrics, and detailed contract analytics.
 - [Truffle](https://github.com/trufflesuite/truffle) - Development environment, testing framework and asset pipeline for Ethereum.
 - [tintinweb/solidity-shell](https://github.com/tintinweb/solidity-shell) - An interactive Solidity shell with lightweight session recording.
+- [th0rgal/verity](https://github.com/th0rgal/verity) - Lean 4 framework for specifying and proving smart contract properties, with EVM-oriented output.
 - [weiroll/weiroll](https://github.com/weiroll/weiroll) - A simple and efficient operation-chaining/scripting language for the EVM.
 
 #### Utility


### PR DESCRIPTION
## Summary

- Add `lfglabs-dev/verity` to Tools > General.
- Use the canonical GitHub URL and alphabetical placement.

## Validation

- [x] Checked the resolved diff with `git diff --check`.
- [x] Confirmed the repository is public, active, MIT-licensed, and has 10+ stars.