### PR TITLE
Add Token Launch Blueprint to Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [austintgriffith/scaffold-eth](https://github.com/austintgriffith/scaffold-eth) - Github template providing an Ethereum dev stack focused on fast product iterations.
 - [ethereum-boilerplate/ethereum-boilerplate](https://github.com/ethereum-boilerplate/ethereum-boilerplate) - React components and hooks to build dApps fast without running your own backend.
 - [gakonst/dapptools-template](https://github.com/gakonst/dapptools-template) - Forkable template to get you started with Dapp Tools.
+- [lordbasilaiassistant-sudo/token-launch-blueprint](https://github.com/lordbasilaiassistant-sudo/token-launch-blueprint) - Production Foundry template for deploying deflationary ERC-20 tokens with bonding curves, treasury-backed intrinsic value, progressive sell tax, and automated fee distribution. 18 contracts, 306 tests.
 - [NodeFactoryIo/solidity-node-docker-starter](https://github.com/NodeFactoryIo/solidity-node-docker-starter) - Github template with Docker containers for building dApps with Truffle and Node.js as backend server.
 - [paulrberg/solidity-template](https://github.com/paulrberg/solidity-template) - Github template for writing contracts (uses: Hardhat, TypeChain, Ethers, Waffle, Solhint, Solcover, Prettier Plugin Solidity).
 - [rhlsthrm/typescript-solidity-dev-starter-kit](https://github.com/rhlsthrm/typescript-solidity-dev-starter-kit) - Starter kit for developing, testing, and deploying smart contracts with a full Typescript environment.


### PR DESCRIPTION
Adds [Token Launch Blueprint](https://github.com/lordbasilaiassistant-sudo/token-launch-blueprint) to the Templates section.

**What it is:** A production Foundry template for deploying deflationary ERC-20 tokens with:
- One-way bonding curve (constant product AMM, buy-side only)
- Treasury-backed intrinsic value floor (IV mathematically cannot decrease)
- Progressive sell tax (25% -> 1% based on hold duration)
- Automated fee distribution via FeeDistributor contracts
- 18 Solidity contracts, 306 Foundry tests
- Deployed and verified on Base mainnet

**Why it fits Templates:** Like scaffold-eth or foundry-template, this is a forkable starter with real contracts, tests, and deployment scripts. Focused specifically on token economics and launch infrastructure.