### PR TITLE
Add EthTools to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@
 - [DiverseSolutions/Diverse-Eth-Calculator](https://github.com/DiverseSolutions/Diverse-Eth-Calculator) - Website with Ethereum unit conversion & utility components.
 - [duaraghav8/Ethlint](https://github.com/duaraghav8/Ethlint) - Linter to identify and fix style & security issues in smart contracts.
 - [Ethereum Unit Converter](https://neptunemutual.com/web3-tools/ethereum-unit-converter/) - Online tool to convert the different ethereum denominations (wei, gwei, ether).
+- [EthTools](https://yishuiliunian.github.io/ethtools/) - Free, open-source, client-side Ethereum developer toolkit: Wei converter, Keccak256 hash, ABI encoder/decoder, address checksum, and more.
 - [ItsNickBarry/hardhat-contract-sizer](https://github.com/ItsNickBarry/hardhat-contract-sizer) - Output contract sizes with Hardhat.
 - [Online ABI Encoder](https://neptunemutual.com/web3-tools/solidity-abi-encoder-online/) - Online Solidity ABI Encoder to encode smart contract arguments, and also perform read and write operations on the blockchain.
 - [prettier-solidity/prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity) - Prettier plugin for automatically formatting your code.


### PR DESCRIPTION
Adding EthTools — a collection of 10 free, client-side Ethereum developer tools (Wei converter, Keccak256, ABI encoder, etc). Hosted on GitHub Pages, MIT licensed, zero dependencies.

Website: https://yishuiliunian.github.io/ethtools/
Source: https://github.com/yishuiliunian/ethtools