### PR TITLE
Add web3vacancy.com to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
 - [cryptojobslist.com](https://cryptojobslist.com/) - Job board for blockchain and cryptocurrency jobs.
 - [crypto.jobs](https://crypto.jobs) - Job board for blockchain and cryptocurrency jobs.
 - [web3.career](https://web3.career) - Job board for blockchain and cryptocurrency jobs.
+- [web3vacancy.com](https://web3vacancy.com) - Crypto & Web3 job board for builders and crypto teams.
 
 ## Libraries
 


### PR DESCRIPTION
Adds [web3vacancy.com](https://web3vacancy.com) to the Jobs section — a crypto & Web3 job board fitting the same category as the existing entries (web3.career, cryptojobslist, etc.).

Followed the existing one-line format:
\`- [web3vacancy.com](https://web3vacancy.com) - Crypto & Web3 job board for builders and crypto teams.\`

Thanks for maintaining this list!