### PR TITLE
Add agentlux/erc-8004

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
 - [0age/HomeWork](https://github.com/0age/HomeWork) - Autonomous utility for finding, sharing, and reusing home addresses for contracts.
 - [0age/Spawner](https://github.com/0age/Spawner) - Spawn EIP 1167 minimal proxies with an included initialization step during contract creation.
 - [0xcert/ethereum-erc721](https://github.com/0xcert/ethereum-erc721) - Non-fungible token implementation for Ethereum-based blockchains.
+- [agentlux/erc-8004](https://github.com/agentlux/erc-8004) - ERC-8004 identity and reputation reference contracts with tests, deploy scripts, and published Base deployment records.
 - [alexvansande/ENSTools](https://github.com/alexvansande/ENSTools) - Set of contracts that extends ENS functionality to other smart contracts.
 - [Arachnid/solidity-stringutils](https://github.com/Arachnid/solidity-stringutils) - Basic string utilities.
 - [dapp-bin](https://github.com/ethereum/dapp-bin) - Ethereum repo providing common data structures and utilities in multiple smart contract languages.


### PR DESCRIPTION
## Summary
- add `agentlux/erc-8004` to the `Libraries` section
- link to the public ERC-8004 reference contracts repo instead of the previous website submission

## Why this belongs
`agentlux/erc-8004` is a public, inspectable reference implementation for ERC-8004 identity and reputation contracts. The repo includes contracts, tests, deploy scripts, and published Base deployment metadata.