### PR TITLE
Annotate eth-brownie/brownie entry with deprecation notice + migration tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@
 - [dapphub/dapptools](https://github.com/dapphub/dapptools) - Command-line-friendly tools for blockchain development.
 - [dethcrypto/ethereum-code-viewer](https://github.com/dethcrypto/ethereum-code-viewer) - View the source of deployed Ethereum contracts in VS Code.
 - [eagr/sol-repl](https://github.com/eagr/sol-repl) - Lightweight, feature-rich REPL for instant feedback.
-- [eth-brownie/brownie](https://github.com/eth-brownie/brownie) - Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
+- [eth-brownie/brownie](https://github.com/eth-brownie/brownie) - Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine. _(Note: Brownie is officially deprecated as of 2023; users are directed to [ApeWorx Ape](https://github.com/ApeWorX/ape). For automated migration, see [`@pugarhuda/brownie-to-ape`](https://github.com/PugarHuda/brownie-to-ape).)_
 - [EthereumStudio](https://github.com/ObsidianLabs/EthereumStudio) - Standalone desktop IDE.
 - [EthFiddle](https://ethfiddle.com/recent_fiddles) - Find, share and embed contracts.
 - [foundry-rs/foundry](https://github.com/foundry-rs/foundry) - Blazing fast, portable and modular toolkit for Ethereum application development written in Rust.


### PR DESCRIPTION
## Summary

1-line annotation to the existing `eth-brownie/brownie` entry in the **Tools** section, noting:

1. Brownie was [officially deprecated in 2023](https://github.com/eth-brownie/brownie/blob/master/README.md) (the deprecation is in the project's own README, but readers of this list don't see it without clicking through).
2. Users are directed to [ApeWorx Ape](https://github.com/ApeWorX/ape) — the recommended successor.
3. For automated migration, [`@pugarhuda/brownie-to-ape`](https://github.com/PugarHuda/brownie-to-ape) is a community-built codemod that automates 80–95% of the Brownie → Ape pattern rewrites with zero false positives.

## Why this is useful

The list currently shows Brownie as a current/active framework, which can mislead readers picking a Solidity development tool today. The 1-line note keeps Brownie in the list (it's still relevant for understanding existing codebases) while giving readers the actual recommended path forward.

## Format / scope

- **Purely additive.** Only appends an italicised parenthetical after the existing one-line description.
- Doesn't remove the Brownie entry — it still appears with its original description.
- Doesn't introduce new sections or restructure anything.

## About the migration codemod referenced

Built for the [Codemod "Boring AI" hackathon](https://dorahacks.io/hackathon/codemod) (DoraHacks 2026), validated on 5 OSS Brownie projects including [`yearn/brownie-strategy-mix`](https://github.com/yearn/brownie-strategy-mix) with 0 false positives. End-to-end verified: after the codemod plus a small AI/manual cleanup pass, `ape compile` succeeds and `ape test --network ::test` returns 38 passed / 0 failed in 5.40s on `brownie-mix/token-mix` ([passing log](https://github.com/PugarHuda/brownie-to-ape/blob/main/docs/ape-verify-token-mix.log)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)