### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 - [Questbook](https://www.questbook.app/) - University DAO offering free crypto-dev courses by leading developers.
 - [Solidity and Vyper cheat sheet](https://reference.auditless.com/cheatsheet) - Review both languages side by side.
 - [topmonks/solidity_quick_ref](https://topmonks.github.io/solidity_quick_ref/) - Syntax overview.
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/?q=solidity) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [useweb3.xyz/tutorials](https://www.useweb3.xyz/tutorials) - Curated list of free community tutorials built around specific projects, tasks, and challenges.
 - [willitscale/learning-solidity](https://github.com/willitscale/learning-solidity) - Complete guide to getting started, creating your own crypto, ICOs, and deployment.
 - [WTF Ethers](https://github.com/WTFAcademy/WTF-Ethers) - Open-source, community-reviewed Ethers.js tutorial in Chinese covering intro and advanced topics [Chinese Language - 中文版].

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - [Questbook](https://www.questbook.app/) - University DAO offering free crypto-dev courses by leading developers.
 - [Solidity and Vyper cheat sheet](https://reference.auditless.com/cheatsheet) - Review both languages side by side.
 - [topmonks/solidity_quick_ref](https://topmonks.github.io/solidity_quick_ref/) - Syntax overview.
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [useweb3.xyz/tutorials](https://www.useweb3.xyz/tutorials) - Curated list of free community tutorials built around specific projects, tasks, and challenges.
 - [willitscale/learning-solidity](https://github.com/willitscale/learning-solidity) - Complete guide to getting started, creating your own crypto, ICOs, and deployment.
 - [WTF Ethers](https://github.com/WTFAcademy/WTF-Ethers) - Open-source, community-reviewed Ethers.js tutorial in Chinese covering intro and advanced topics [Chinese Language - 中文版].


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/?q=solidity) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/?q=solidity) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.