### PR TITLE
Add MerkleBlue/defimath to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@
 - [maple-labs/erc-20](https://github.com/maple-labs/erc-20) - Maple implementation of the ERC-20 standard.
 - [mattdf/RingCrypto](https://github.com/mattdf/RingCrypto) - Ring signature related implementations for Ethereum.
 - [mds1/solidity-trigonometry](https://github.com/mds1/solidity-trigonometry) - Library with basic trigonometry functions.
+- [MerkleBlue/defimath](https://github.com/MerkleBlue/defimath) - Gas-optimized library for DeFi math: Black-Scholes pricing, Greeks, interest rates, and statistics.
 - [Modular Libraries](https://github.com/modular-network/ethereum-libraries) - Deployed utility libraries to use in your smart contracts.
 - [mzhu25/sol2string](https://github.com/mzhu25/sol2string) - `LibUintToString` library for efficiently converting `uint256` values to strings.
 - [NTA-Capital/SolMATe](https://github.com/NTA-Capital/SolMATe) - Libraries for floating-point matrix manipulation, linear algebra operations, and vector math.


### PR DESCRIPTION
Adds [MerkleBlue/defimath](https://github.com/MerkleBlue/defimath) to the Libraries section.

It's a pure-Solidity, MIT-licensed library of DeFi math primitives — Black-Scholes option pricing (~2,876 gas, ~4.6× cheaper than the next-best on-chain implementation), Greeks, IV solver, interest-rate math, and statistics (volatility, Sharpe, VaR, CVaR, max drawdown). No runtime dependencies.

Entry inserted alphabetically between `mds1/solidity-trigonometry` and `Modular Libraries`. Followed the contributing guidelines: `[name](link) - Description.`, capitalized, period at end.

[Please describe your pull request here]

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
- [ ] Avoid repeating the word `Solidity` in the description.
