### PR TITLE
Add protoscan — on-chain protocol state tracker and diff tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 
 - [Embark](https://github.com/embark-framework/embark) - Framework that allows you to easily develop and deploy DApps.
 - [Moesif](https://www.moesif.com/docs/platform/ethereum-web3/) - Service that provides Ethereum smart contract analytics and anomaly detection for DApps and DAPIs.
+- [protoscan](https://github.com/dumtban/protoscan) - On-chain protocol state tracker and diff tool. Snapshots admin addresses, proxy implementations, and parameters across chains for DeFi protocols.
 
 ## Languages
 


### PR DESCRIPTION
## What is protoscan?

CLI tool that snapshots on-chain protocol state (proxy implementations, admin addresses, parameters, access control) and diffs between snapshots to detect changes.

Ships with a curated registry for 11 DeFi protocols (Aave V3, Compound V3, Uniswap V3, Maker, EigenLayer, Lido, Morpho Blue, Pendle, Curve, Yearn V3, GMX V2) across multiple chains.

## Why

With Defender sunsetting, there is less tooling for tracking deployed protocol state across chains. protoscan fills that gap as a self-hosted CLI.

- npm: https://www.npmjs.com/package/protoscan
- GitHub: https://github.com/dumtban/protoscan