### PR TITLE
Add Semantic Dapp to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@
 - [OpenZeppelin](https://openzeppelin.com/) - Framework to build secure smart contracts.
 - [raineorshine/solidity-repl](https://github.com/raineorshine/solidity-repl) - REPL CLI.
 - [Remix](https://remix.ethereum.org/) - Online real-time compiler and runtime.
+- [Semantic Dapp](https://github.com/TacitvsXI/semantic-dapp) - Generate a usable user dApp and admin console from any EVM ABI with deterministic risk and audience classification.
 - [SIF](https://github.com/chao-peng/SIF) - Code generation from the AST, analyze and instrument source code.
 - [Smart Contract Sanctuary](https://github.com/tintinweb/smart-contract-sanctuary) - Home for Ethereum smart contracts, with verified contracts from Etherscan.
 - [sol-merger](https://github.com/RyuuGan/sol-merger) - Merge all imports into a single file for contracts.


### PR DESCRIPTION
## Summary
Adds [Semantic Dapp](https://github.com/TacitvsXI/semantic-dapp) under **Tools → General** (alphabetically after Remix).

## Checklist
- [x] The URL is not already present in the list
- [x] Description starts with uppercase and ends with a period
- [x] No `A` / `An` prefix on the description
- [x] Does not repeat the word `Solidity` in the description

## Why include
Open-source tool that turns any deployed EVM contract ABI into a usable User / Admin / Raw console with deterministic risk/audience classification. Useful next to other dApp/dev tooling in this list.

- Demo: https://tacitvsxi.github.io/semantic-dapp/
- Repo: https://github.com/TacitvsXI/semantic-dapp