### PR TITLE
Add Testnet Faucets to Tools > General

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@
 - [solidity-docgen](https://github.com/OpenZeppelin/solidity-docgen) - Documentation generator for smart contract projects.
 - [Sourcify](https://sourcify.dev/) - Decentralized and open-sourced smart contract verification service.
 - [Tenderly](https://tenderly.co) - Easily monitor your smart contracts with error tracking, alerting, performance metrics, and detailed contract analytics.
+- [Testnet Faucets](https://testnetfaucets.dev) - Directory of testnet faucets across 40+ networks, health-checked daily and verified on-chain, with a free JSON API.
 - [tintinweb/solidity-shell](https://github.com/tintinweb/solidity-shell) - Interactive shell with lightweight session recording.
 - [Truffle](https://github.com/trufflesuite/truffle) - Development environment, testing framework, and asset pipeline for Ethereum.
 - [weiroll/weiroll](https://github.com/weiroll/weiroll) - Simple and efficient operation-chaining/scripting language for the EVM.


### PR DESCRIPTION
Adds [Testnet Faucets](https://testnetfaucets.dev), a live directory of blockchain testnet faucets across 40+ networks, health-checked daily and verified on-chain (it reads each dispensing wallet's live balance and payout history). It also offers a free JSON API and a CI preflight tool, useful to Solidity developers picking a working faucet before testing. Inserted alphabetically under Tools > General (after Tenderly), matching the existing entry format; complements the existing MultiFaucet entry.