### PR TITLE
Add contract::rw to Tools > General

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@
 #### General
 
 - [Anish-Agnihotri/MultiFaucet](https://github.com/Anish-Agnihotri/MultiFaucet) - MultiFaucet drips ETH, tokens, and NFTs across many testnet networks, at once.
+- [contract::rw](https://contractrw.dev/) - Browser console to read/write any EVM contract from an ABI on any chain or custom RPC; includes selector and calldata decoding.
 - [create-truffle-dapp](https://github.com/clemlak/create-truffle-dapp) - CLI to create and deploy Truffle projects with no configuration.
 - [dapp-scratch](https://github.com/okwme/dapp-scratch) - CLI for generating JavaScript modules from contracts for decentralized apps.
 - [dapphub/dapptools](https://github.com/dapphub/dapptools) - Command-line-friendly tools for blockchain development.


### PR DESCRIPTION
Adds contract::rw, a free browser-based read/write console for EVM contracts. Unlike explorer-based interaction it doesn't require verified source — paste any ABI and point it at any chain or a custom RPC (incl. local anvil/hardhat). Also decodes revert errors and transaction calldata. Placed under [Tools / General] to match the surrounding entries.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid repeating the word `Solidity` in the description.
