### PR TITLE
Add Al-Mizaan Judge to Tools/Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@
 
 - [a16z/metamorphic-contract-detector](https://github.com/a16z/metamorphic-contract-detector) - Check whether a given contract exhibits red flags that could indicate the potential for metamorphism instead of immutability.
 - [Aderyn](https://github.com/Cyfrin/aderyn) - Rust-based open-source static analyzer for finding vulnerabilities in smart contracts.
+- [Al-Mizaan Judge](https://github.com/holistis/al-mizaan-judge) - CLI that runs a bug bounty finding through an adversarial debate before you spend a contest submission on it.
 - [Echidna](https://github.com/crytic/echidna) - Define properties for your smart contract then use fuzzing to catch security bugs.
 - [eth-sri/securify2](https://github.com/eth-sri/securify2) - Tool for analyzing smart contracts for vulnerabilities and insecure coding.
 - [ethereum/sourcify](https://github.com/ethereum/sourcify) - Re-compiler for verifying that bytecode corresponds to specific source code.


### PR DESCRIPTION
Adds a CLI tool that runs a bug bounty finding through a strict, structured adversarial-debate judge (Defender/Attacker/Judge, up to 3 rounds) before you spend a real submission on Sherlock, Immunefi, or Cantina. Mechanical gates catch the cheap kills for free (trusted-actor-only attacker, unproven oracle economics), the debate handles the harder reasoning (reachability, invariant breach, protocol intent, dollar impact). Published on npm, MIT licensed.

- Repo: https://github.com/holistis/al-mizaan-judge
- npm: https://www.npmjs.com/package/al-mizaan-judge

## Checklist

- [x] The URL is not already present in the list (checked with CTRL+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid repeating the word `Solidity` in the description.