### PR TITLE
Add hook-safety-gate to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 - [0xcert/ethereum-erc721](https://github.com/0xcert/ethereum-erc721) - Non-fungible token implementation for Ethereum-based blockchains.
 - [alexvansande/ENSTools](https://github.com/alexvansande/ENSTools) - Set of contracts that extends ENS functionality to other smart contracts.
 - [Arachnid/solidity-stringutils](https://github.com/Arachnid/solidity-stringutils) - Basic string utilities.
+- [blazephoenixxyz-crypto/hook-safety-gate](https://github.com/blazephoenixxyz-crypto/hook-safety-gate-v3) - Default-closed admission gate for routing through Uniswap v4 hooks: screens return-delta permissions by address bitmask, pins each admitted hook's EXTCODEHASH so a proxy upgrade stops it being routable, zero dependencies.
 - [dapp-bin](https://github.com/ethereum/dapp-bin) - Ethereum repo providing common data structures and utilities in multiple smart contract languages.
 - [dapphub/dappsys](https://github.com/dapphub/dappsys) - Contract system framework for flexible multi-contract dapps.
 - [dmihal/hardhat-interface-generator](https://github.com/dmihal/hardhat-interface-generator) - Hardhat plugin to automatically generate interfaces from code.


### PR DESCRIPTION
Adds [hook-safety-gate](https://github.com/blazephoenixxyz-crypto/hook-safety-gate-v3) to **Libraries**, in alphabetical position after Arachnid/solidity-stringutils.

A standalone, default-closed admission gate for the routing side of Uniswap v4 hook safety — for routers and aggregators deciding which hooks they are willing to route user funds through, rather than for hook authors. Same spirit as the other reusable single-purpose contracts already in this section.

Three layers, one line to integrate:

- **Delta-permission screen** — the permission bits live in the hook's own address, so the check is arithmetic on a bitmask: constant time, no external call, nothing the hook can misreport.
- **Codehash pinning** — `EXTCODEHASH` recorded at admission and re-checked at routing, so a hook whose code changes after review (proxy upgrade, redeploy) stops being routable rather than silently continuing.
- **Timelocked delta admission** — return-delta hooks go through propose/confirm with a delay, and confirmation reverts if the code changed in between.

MIT, zero external dependencies (the v4 flag constants are redeclared verbatim and pinned by a test, so it audits and deploys in isolation), 38 tests at 768 fuzz runs.

Worth stating plainly rather than leaving to be discovered: admission is owner-controlled, so this expresses an integrator's own risk policy — it is not a trustless mechanism.