### PR TITLE
Add Kerne Verify Anything to Tools > General

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@
 - [foundry-rs/foundry](https://github.com/foundry-rs/foundry) - Blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
 - [Hardhat](https://hardhat.org/) - Development environment to compile, deploy, test, and debug your Ethereum software.
 - [instant-dapp-ide](https://github.com/dominicwilliams/instant-dapp-ide) - Complete dApp development environment as a Docker image you can run from the command line.
+- [Kerne Verify Anything](https://kerne.fi/verify-anything) - Paste any Base or Ethereum stablecoin address and recompute its on-chain backing and ERC-4626 vault accounting in the browser, client-side, with no login.
 - [Laika](https://getlaika.app) - Make requests to smart contracts without the hassle of writing a single line of code.
 - [naddison36/sol2uml](https://github.com/naddison36/sol2uml) - Unified Modeling Language (UML) class diagram generator for smart contracts.
 - [OpenZeppelin](https://openzeppelin.com/) - Framework to build secure smart contracts.


### PR DESCRIPTION
Adds a free browser tool for checking a deployed stablecoin's backing yourself.

Paste any Base or Ethereum stablecoin address and it reads supply and reserves live from the chain, recomputes ERC-4626 vault share accounting, and separates the part of the backing that is verifiable on chain from the part that requires trusting an attestor. Everything runs client-side in the page: no login, no account, no API key, nothing stored. It is not an audit and does not present itself as one.

Placed in Tools > General, in alphabetical position between `instant-dapp-ide` and `Laika`.

Disclosure: I work on Kerne, which publishes the tool. It is free and ungated. The same entry is already carried in saeidshirazi/Awesome-Smart-Contract-Security.

## Checklist

- [x] The URL is not already present in the list (checked the raw markdown).
- [x] The description starts with an uppercase character and ends with a period.
- [x] No `A` / `An` prefix at the start of the description.
- [x] The description does not repeat the word `Solidity`.
- [x] Alphabetical order within the category.
- [x] No trailing whitespace.
