### PR TITLE
Repoint Scaffold-ETH to scaffold-eth-2 in Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,12 @@
 
 #### Templates
 
-- [austintgriffith/scaffold-eth](https://github.com/austintgriffith/scaffold-eth) - GitHub template providing an Ethereum dev stack focused on fast product iterations.
 - [ethereum-boilerplate/ethereum-boilerplate](https://github.com/ethereum-boilerplate/ethereum-boilerplate) - React components and hooks to build dApps fast without running your own backend.
 - [gakonst/dapptools-template](https://github.com/gakonst/dapptools-template) - Forkable template to get you started with Dapp Tools.
 - [NodeFactoryIo/solidity-node-docker-starter](https://github.com/NodeFactoryIo/solidity-node-docker-starter) - GitHub template with Docker containers for building dApps with Truffle and Node.js as a backend server.
 - [paulrberg/solidity-template](https://github.com/paulrberg/solidity-template) - GitHub template for writing contracts with Hardhat, TypeChain, Ethers, Waffle, Solhint, Solcover, and a Prettier plugin.
 - [rhlsthrm/typescript-solidity-dev-starter-kit](https://github.com/rhlsthrm/typescript-solidity-dev-starter-kit) - Starter kit for developing, testing, and deploying smart contracts with a full TypeScript environment.
+- [scaffold-eth/scaffold-eth-2](https://github.com/scaffold-eth/scaffold-eth-2) - Forkable Ethereum dev stack for building dApps, with a Next.js frontend, wagmi hooks and reusable web3 components.
 - [tomhirst/solidity-nextjs-starter](https://github.com/tomhirst/solidity-nextjs-starter) - Full-stack dApp starter built with Next.js (React).
 - [transmissions11/foundry-template](https://github.com/transmissions11/foundry-template) - Streamlined template for getting started with Foundry and Solmate.
 - [wighawag/template-ethereum-contracts](https://github.com/wighawag/template-ethereum-contracts) - Template to develop smart contracts.


### PR DESCRIPTION
Repoints the Scaffold-ETH entry under Resources > Templates from the archived v1 repo to the maintained [scaffold-eth/scaffold-eth-2](https://github.com/scaffold-eth/scaffold-eth-2).

The listed `austintgriffith/scaffold-eth` was archived in June 2024 and has since been transferred, so the URL now silently redirects to `scaffold-eth/scaffold-eth`. Because the CI link check runs with `--allow-redirect`, it stays green and the staleness is invisible. Scaffold-ETH 2 is the version the project maintains and links from scaffoldeth.io.

The description is rewritten to match the contribution rules and to describe what SE-2 actually is: it is no longer a GitHub template, projects are scaffolded with `npx create-eth@latest`.

Entry moved from the top of the section to between `rhlsthrm/typescript-solidity-dev-starter-kit` and `tomhirst/solidity-nextjs-starter` to keep Templates alphabetical. One line changed, no other files touched.

`awesome_bot` is not installed locally, so the full sweep runs in CI. The one URL this PR introduces was verified manually: 200, no redirect.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid repeating the word `Solidity` in the description.
