### PR TITLE
Add slither-chat: AI copilot for smart-contract audits (runs Slither, explains findings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@
 - [Mythril](https://github.com/ConsenSys/mythril) - Security analysis tool for smart contracts.
 - [MythX](https://mythx.io/) - Detect security vulnerabilities in Ethereum smart contracts throughout the development lifecycle.
 - [Slither](https://github.com/crytic/slither) - Static analyzer with support for many common bug types, including visualization tools for security-relevant information.
+- [slither-chat](https://github.com/pxlcrtiv/slither-chat) - AI copilot for smart-contract audits: runs Slither, then classifies, explains, and suggests patches for every finding in plain English.
 
 #### DevOps
 


### PR DESCRIPTION
## What
Adds [slither-chat](https://github.com/pxlcrtiv/slither-chat) to the Tools > Audit section, placed alphabetically after Slither per CONTRIBUTING.

## Why it belongs
- slither-chat runs **Slither** automatically on a Solidity codebase, then classifies and explains every detector finding in plain English (offline knowledge base, on-device Hugging Face zero-shot vulnerability classifier, or any OpenAI-compatible LLM), with patch hints as unified diffs.
- MIT licensed, fully keyless (works offline on CPU), 56 passing tests, benchmarked against 1,748 real audited contracts (recall 0.968).
- Complements the existing static analyzers in this section: it is the explanation/education layer on top of Slither rather than another detector.