### PR TITLE
Add theshakeel/evm-calldata-decoder to Tools > Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@
 - [sambacha/prettier-config-solidity](https://github.com/sambacha/prettier-config-solidity) - Prettier config optimized to reduce AST churn and conform to the language spec.
 - [sc-forks/solidity-coverage](https://github.com/sc-forks/solidity-coverage) - Code coverage tool.
 - [Tenderly/tenderly-cli](https://github.com/Tenderly/tenderly-cli) - Speed up your development with error stack traces.
+- [theshakeel/evm-calldata-decoder](https://github.com/theshakeel/evm-calldata-decoder) - Library + CLI to decode and encode EVM calldata from human-readable function signatures, with selector verification.
 - [tintinweb/solgrep](https://github.com/tintinweb/solgrep) - Scriptable semantic grep utility.
 
 #### Audit


### PR DESCRIPTION
Adds [evm-calldata-decoder](https://github.com/theshakeel/evm-calldata-decoder) — an MIT-licensed library + CLI that decodes and encodes EVM transaction calldata from human-readable function signatures.

Why it should be included: it complements the existing ABI utilities in this section — unlike the hosted calldata decoder already listed, this one is open source and works offline/in CI as a CLI (`calldata decode`, `calldata encode`, `calldata selector`), with automatic 4-byte selector verification (flags a selector mismatch with a non-zero exit code) and depth-aware parsing so tuple types with nested commas parse correctly. Built on ethers v6.

Follows the guidelines: single suggestion, alphabetical placement, `[name](link) - Description.` format.